### PR TITLE
Node parents & return type checking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Lexer } from './lexer';
 import { TokenType } from './lexer/tokens';
 import { Parser } from './parser';
 import { Function } from './parser/node/function';
+import { Node } from './parser/node/node';
 import { TokenStream } from './parser/tokenStream';
 import { TypeScriptCodeGenPass } from './passes/codegen/typeScript';
 import { PassManager } from './passes/manager';
@@ -16,6 +17,8 @@ const lexer = new Lexer(input);
 
 const out = lexer.lex().filter(t => t.type !== TokenType.Whitespace);
 // console.log('OUT: \n', out);
+
+export const symbolTable: Map<string, Node> = new Map();
 
 const stream = new TokenStream(out);
 const parser = new Parser(stream);

--- a/src/parser/node/block.ts
+++ b/src/parser/node/block.ts
@@ -1,8 +1,9 @@
 import { Pass } from '../../passes/pass';
-import { Node, NodeType } from './node';
+import { Function } from './function';
+import { ChildNode, NodeType } from './node';
 import { Statement } from './statement/statement';
 
-export class Block extends Node {
+export class Block extends ChildNode<Function> {
 	constructor(public readonly statements: Statement[]) {
 		super(NodeType.Block);
 	}

--- a/src/parser/node/function.ts
+++ b/src/parser/node/function.ts
@@ -7,8 +7,8 @@ export class Function extends Node {
 	public id: string;
 
 	constructor(
-		public readonly declaration: FunctionDeclaration,
-		public readonly block: Block
+		public declaration: FunctionDeclaration,
+		public block: Block
 	) {
 		super(NodeType.Function);
 		this.id = declaration.id;

--- a/src/parser/node/node.ts
+++ b/src/parser/node/node.ts
@@ -11,10 +11,17 @@ export enum NodeType {
 	Argument = 'argument',
 }
 
-export abstract class Node {
+export abstract class Node<T = undefined> {
+	constructor(
+		public readonly nodeType: NodeType,
+		public parent?: T
+	) {}
+
 	abstract accept(pass: Pass): void;
+
 	getChildren(): Node[] {
 		return [];
 	}
-	constructor(public readonly nodeType: NodeType) {}
 }
+
+export abstract class ChildNode<T extends Node> extends Node<T> {}

--- a/src/parser/node/node.ts
+++ b/src/parser/node/node.ts
@@ -11,11 +11,8 @@ export enum NodeType {
 	Argument = 'argument',
 }
 
-export abstract class Node<T = undefined> {
-	constructor(
-		public readonly nodeType: NodeType,
-		public parent?: T
-	) {}
+export abstract class Node {
+	constructor(public readonly nodeType: NodeType) {}
 
 	abstract accept(pass: Pass): void;
 
@@ -24,4 +21,10 @@ export abstract class Node<T = undefined> {
 	}
 }
 
-export abstract class ChildNode<T extends Node> extends Node<T> {}
+export abstract class ChildNode<T> extends Node {
+	parent?: T;
+
+	constructor(public nodeType: NodeType) {
+		super(nodeType);
+	}
+}

--- a/src/parser/node/statement/function/argument.ts
+++ b/src/parser/node/statement/function/argument.ts
@@ -1,8 +1,9 @@
 import { Pass } from '../../../../passes/pass';
-import { Node, NodeType } from '../../node';
+import { ChildNode, NodeType } from '../../node';
 import { Type } from '../../type';
+import { FunctionDeclaration } from './declaration';
 
-export class Argument extends Node {
+export class Argument extends ChildNode<FunctionDeclaration> {
 	constructor(public readonly id: string, public readonly type: Type) {
 		super(NodeType.Argument);
 	}

--- a/src/parser/node/statement/statement.ts
+++ b/src/parser/node/statement/statement.ts
@@ -1,4 +1,5 @@
-import { Node, NodeType } from '../node';
+import { Block } from '../block';
+import { ChildNode, NodeType } from '../node';
 
 export enum StatementType {
 	VariableDeclaration = 'variableDeclaration',
@@ -7,7 +8,7 @@ export enum StatementType {
 	Return = 'return',
 }
 
-export abstract class Statement extends Node {
+export abstract class Statement extends ChildNode<Block> {
 	constructor(public statementType: StatementType) {
 		super(NodeType.Statement);
 	}

--- a/src/parser/node/statement/statement.ts
+++ b/src/parser/node/statement/statement.ts
@@ -8,7 +8,7 @@ export enum StatementType {
 	Return = 'return',
 }
 
-export abstract class Statement extends ChildNode<Block> {
+export abstract class Statement extends ChildNode<Block | undefined> {
 	constructor(public statementType: StatementType) {
 		super(NodeType.Statement);
 	}

--- a/src/passes/type/index.ts
+++ b/src/passes/type/index.ts
@@ -1,3 +1,4 @@
+import { Return } from '../../parser/node/statement/return';
 import { VariableDeclaration } from '../../parser/node/statement/variableDeclaration';
 import { Pass } from '../pass';
 
@@ -6,6 +7,18 @@ export class TypeCheckPass extends Pass {
 		if (statement.type.kind !== statement.value.type.kind)
 			throw Error(
 				`Variable declaration type mismatch: ${statement.id} should be type ${statement.type.kind} but is instead type ${statement.value.type.kind}`
+			);
+	}
+
+	visitReturnStatement(statement: Return) {
+		if (!statement.parent || !statement.parent.parent)
+			throw Error('Illegal return statement');
+		const returnType = statement.parent.parent.declaration.returnType.kind;
+		const valueType = statement.value.type.kind;
+		const functionId = statement.parent.parent.id;
+		if (statement.value.type !== statement.parent.parent.declaration.returnType)
+			throw Error(
+				`Return type mismatch: function ${functionId} should return type ${returnType} but instead returns type ${valueType}`
 			);
 	}
 }


### PR DESCRIPTION
- Attaches information about parents to Nodes (with ChildNode)
- Type-checks `return` statements
  - Example input:
    ```
    fn int abc(str a, int b) {
	   return "string here"; // this is not supposed to work (ret type is int)
    }
    ```
  - Compiler output:
    > Error: Return type mismatch: function abc should return type integer but instead returns type string
